### PR TITLE
Only do codecoverage in user code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 deps/deps.jl
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # julia-treeshake Action
 
-Run package tests or a given script to see if any project dependencies are unused.
+Run package tests or a given script to see if any project dependencies are unused via code coverage evaluation.
 
 ## Note
 
@@ -8,9 +8,7 @@ Run package tests or a given script to see if any project dependencies are unuse
 the coverage of the package tests, or provided test script. Also consider that the setup of the CI
 machine may impact coverage, with platform-guarded code usage hiding real code usage on other platforms.
 
-2) Tests will be run with `--code-coverage=user` which may slow down execution significantly.
-
-3) If a dependency is only `using/import`-ed but has an `__init__()`, it will be marked as used.
+2) If a dependency is only `using/import`-ed but has an `__init__()`, it will be marked as used.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Run package tests or a given script to see if any project dependencies are unuse
 the coverage of the package tests, or provided test script. Also consider that the setup of the CI
 machine may impact coverage, with platform-guarded code usage hiding real code usage on other platforms.
 
-2) Tests will be run with `--code-coverage=all` which may slow down execution significantly.
+2) Tests will be run with `--code-coverage=user` which may slow down execution significantly.
 
 3) If a dependency is only `using/import`-ed but has an `__init__()`, it will be marked as used.
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
 inputs:
   test_code:
     description: 'Code to run while evaluating dependency usage'
-    default: 'import Pkg; Pkg.test(julia_args=["--code-coverage=all"])'
+    default: 'import Pkg; Pkg.test(julia_args=["--code-coverage=user"])'
     required: false
   prefix:
     description: 'Value inserted in front of the julia command, e.g. for running xvfb-run julia [...]'
@@ -25,7 +25,7 @@ runs:
   steps:
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --code-coverage=all --color=yes --project=${{ inputs.project }} -e '${{ inputs.test_code }}' )
+        julia_cmd=( julia --code-coverage=user --color=yes --project=${{ inputs.project }} -e '${{ inputs.test_code }}' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"


### PR DESCRIPTION
I had misunderstood what `--code-coverage=user` meant, I thought it was just the active project's src. But given it's all non-base non-stdlib code, it's the right thing to use.

Tested in https://github.com/IanButterworth/TreeShakeTest.jl/runs/3094412777